### PR TITLE
feat: add deeper support for Solidity metadata decoding

### DIFF
--- a/evm_asm/assembler.py
+++ b/evm_asm/assembler.py
@@ -75,6 +75,9 @@ def _split_metadata(bytecode: Bytecode) -> Tuple[Bytecode, Metadata]:
         return bytecode, Metadata(b"")
 
     metadata_length = int.from_bytes(bytecode[-1:], "big") + 2
+    if len(bytecode) < metadata_length:
+        return bytecode, Metadata(b"")
+
     # 0xa1, 0xa2 are known Solidity metadata start codes
     if bytecode[-metadata_length] in (161, 162):
         return (

--- a/evm_asm/assembler.py
+++ b/evm_asm/assembler.py
@@ -119,6 +119,7 @@ def _split_string_literals(bytecode: Bytecode) -> Tuple[Bytecode, bytes]:
     reversed_bytecode = bytearray(bytecode)
     reversed_bytecode.reverse()
 
+    last_stopcode_idx = len(bytecode)
     for idx, code in enumerate(reversed_bytecode):
         # a contract must end in one of these
         if code in END_OPCODES:

--- a/evm_asm/assembler.py
+++ b/evm_asm/assembler.py
@@ -136,7 +136,9 @@ def _split_string_literals(bytecode: Bytecode) -> Tuple[Bytecode, bytes]:
     return Bytecode(bytecode[:last_stopcode_idx]), bytecode[last_stopcode_idx:]
 
 
-def disassemble(evm: Fork, bytecode: Bytecode) -> Assembly:
+def disassemble(
+    evm: Fork, bytecode: Bytecode, include_metadata: bool = True
+) -> Assembly:
     bytecode, metadata = _split_metadata(bytecode)
     bytecode, string_literals = _split_string_literals(bytecode)
 
@@ -156,5 +158,5 @@ def disassemble(evm: Fork, bytecode: Bytecode) -> Assembly:
     if len(string_literals) > 0:
         yield string_literals  # String literals are at the end of the code
 
-    if metadata:
+    if include_metadata and metadata:
         yield metadata  # Metadata exists past the end of the code

--- a/evm_asm/assembler.py
+++ b/evm_asm/assembler.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Dict, Optional, Tuple
 
 from evm_asm.errors import (
     InvalidOpcodeInput,
@@ -14,6 +14,14 @@ from evm_asm.typing import (
 from evm_asm.forks import Fork
 
 
+END_OPCODES = (
+    0x00,  # STOP
+    0xF3,  # RETURN
+    0xFD,  # REVERT
+    0xFE,  # INVALID
+)
+
+
 def assemble(evm: Fork, assembly: Assembly) -> Bytecode:
     bytecode = bytearray(b"")
     assembly_iter = iter(assembly)
@@ -24,13 +32,7 @@ def assemble(evm: Fork, assembly: Assembly) -> Bytecode:
         if (
             isinstance(code, bytes)
             and last_opcode
-            and last_opcode.opcode_value
-            in (
-                0,  # STOP
-                243,  # RETURN
-                253,  # REVERT
-                254,  # INVALID
-            )
+            and last_opcode.opcode_value in END_OPCODES
         ):
             if len(code) > 0:
                 bytecode.extend(code)
@@ -69,23 +71,48 @@ def assemble(evm: Fork, assembly: Assembly) -> Bytecode:
     return Bytecode(bytecode)
 
 
-def _split_metadata(bytecode: Bytecode) -> Tuple[Bytecode, Metadata]:
-    # Pattern is `(0xa1|0xa2).*0x00.`, so 2nd to last byte must be 0x00
-    if bytecode[-2] != 0:
-        return bytecode, Metadata(b"")
+def valid_metadata(metadata: bytes) -> bool:
+    import cbor2 as cbor  # type: ignore
 
-    metadata_length = int.from_bytes(bytecode[-1:], "big") + 2
+    try:
+        metadata = cbor.loads(metadata[:-2])  # NOTE: Ignore 2 length bytes at end
+    except MemoryError:
+        return False
+
+    if not isinstance(metadata, dict):
+        return False
+
+    if "bzzr0" not in metadata and "solc" not in metadata:
+        return False
+
+    return True
+
+
+def _split_metadata(bytecode: Bytecode) -> Tuple[Bytecode, Optional[Metadata]]:
+    # In Solidity, last 2 bytes is the length of the metadata (if applicable)
+    metadata_length = int.from_bytes(bytecode[-2:], "big") + 2
     if len(bytecode) < metadata_length:
-        return bytecode, Metadata(b"")
+        # Can't decode metadata with improper length
+        return bytecode, None
 
-    # 0xa1, 0xa2 are known Solidity metadata start codes
-    if bytecode[-metadata_length] in (161, 162):
+    elif valid_metadata(bytecode[-metadata_length:]):
         return (
             Bytecode(bytecode[:-metadata_length]),
             Metadata(bytecode[-metadata_length:]),
         )
+
     else:
-        return bytecode, Metadata(b"")
+        return bytecode, None
+
+
+def get_metadata(bytecode: Bytecode) -> Dict:
+    import cbor2 as cbor  # type: ignore
+
+    _, metadata = _split_metadata(bytecode)
+    if metadata:
+        return cbor.loads(metadata[:-2])
+    else:
+        return {}
 
 
 def _split_string_literals(bytecode: Bytecode) -> Tuple[Bytecode, bytes]:
@@ -93,13 +120,8 @@ def _split_string_literals(bytecode: Bytecode) -> Tuple[Bytecode, bytes]:
     reversed_bytecode.reverse()
 
     for idx, code in enumerate(reversed_bytecode):
-        # Record the last "stop" opcode (a contract must end in one of these)
-        if code in (
-            0,  # STOP
-            243,  # RETURN
-            253,  # REVERT
-            254,  # INVALID
-        ):
+        # a contract must end in one of these
+        if code in END_OPCODES:
             # NOTE: Index is from end of bytecode
             last_stopcode_idx = len(bytecode) - idx
 
@@ -112,11 +134,6 @@ def _split_string_literals(bytecode: Bytecode) -> Tuple[Bytecode, bytes]:
 
     # Return the code up to the last "stop" opcode prior to a big string sequence
     return Bytecode(bytecode[:last_stopcode_idx]), bytecode[last_stopcode_idx:]
-
-
-def get_metadata(bytecode: Bytecode) -> Metadata:
-    _, metadata = _split_metadata(bytecode)
-    return metadata
 
 
 def disassemble(evm: Fork, bytecode: Bytecode) -> Assembly:
@@ -139,5 +156,5 @@ def disassemble(evm: Fork, bytecode: Bytecode) -> Assembly:
     if len(string_literals) > 0:
         yield string_literals  # String literals are at the end of the code
 
-    if len(metadata) > 0:
+    if metadata:
         yield metadata  # Metadata exists past the end of the code

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages  # type: ignore
 
 
 extras_require = {
+    "cbor": ["cbor==5.2.0"],
     "test": [
         "py-evm==0.3.0a20",
         "pytest==6.2.1",
@@ -31,6 +32,7 @@ extras_require = {
     ],
 }
 
+extras_require["test"] = extras_require["test"] + extras_require["cbor"]
 extras_require["dev"] = (
     extras_require["dev"]
     + extras_require["test"]  # noqa: W504


### PR DESCRIPTION
This PR adds support for decoding Solidity metadata during decompilation according to CBOR (which is defined as an optional extra)

This PR also fixes a bug when decoding bytecode without additional metadata where the "length" attribute was not properly checked